### PR TITLE
Fix process_estimates_pe() when multiple catch groups defined

### DIFF
--- a/R_functions/process_estimates_pe.R
+++ b/R_functions/process_estimates_pe.R
@@ -125,10 +125,12 @@ process_estimates_pe <- function(analysis_lut, estimates_pe) {
   # Catch 
   #calculate days open and days surveyed
   totaldaysopen_totaldayssurveyed <-transformed_pe_data$pe_summarized_catch |> 
-    dplyr::distinct(period, day_type, n_obs, N_days_open) |> 
+    dplyr::distinct(period, day_type, est_cg, n_obs, N_days_open) |> 
+    dplyr::group_by(est_cg) |> 
     dplyr::summarise(
       totaldaysopen = sum(N_days_open),
-      totalobs = sum(n_obs)
+      totalobs = sum(n_obs),
+      .groups = 'drop'
     )
   
   #catch transformation
@@ -165,11 +167,10 @@ process_estimates_pe <- function(analysis_lut, estimates_pe) {
                  names_to = "estimate_type",
                  values_to = "value") |> 
     dplyr::mutate(
-      analysis_id = transformed_pe_data$pe_summarized_catch$analysis_id,
-      project_name = transformed_pe_data$pe_summarized_catch$project_name,
-      fishery_name = transformed_pe_data$pe_summarized_catch$fishery_name,
-      model_type = transformed_pe_data$pe_summarized_catch$model_type,
-      est_cg = transformed_pe_data$pe_summarized_catch$est_cg,
+      analysis_id = unique(transformed_pe_data$pe_summarized_catch$analysis_id),
+      project_name = unique(transformed_pe_data$pe_summarized_catch$project_name),
+      fishery_name = unique(transformed_pe_data$pe_summarized_catch$fishery_name),
+      model_type = unique(transformed_pe_data$pe_summarized_catch$model_type),
       #same date consideration as above
       min_event_date = as.Date(params$est_date_start),
       max_event_date = as.Date(


### PR DESCRIPTION
The object "totaldaysopen_totaldayssurveyed" was added during the ETL PR review process. When implementing this I apparently did so using only one catch group. This mean that when >1 catch group was defined process_estimates_pe() would fail. Grouping by "est_cg" and then pulling the unique metadata values for the analysis_id, fishery_name, etc. fixes the issue. Tested once on the Puyallup Carbon salmon 2024 dataset on 9/18/2024.