### PR TITLE
Cleanup of ETL functions before implementation

### DIFF
--- a/R_functions/establish_db_con.R
+++ b/R_functions/establish_db_con.R
@@ -34,7 +34,7 @@ establish_db_con<- function(max_attempts = 5, delay_seconds = 3) {
   if (!DBI::dbIsValid(con)) {
     stop("Failed to establish connection after ", max_attempts, " attempts.")
   } else {
-    cat("Database connection established.\n")
+    cat("\nDatabase connection established.\n")
   }
   
   return(con)

--- a/R_functions/export_estimates.R
+++ b/R_functions/export_estimates.R
@@ -64,31 +64,31 @@ export_estimates <- function(params, analysis_lut, creel_estimates) {
         if (params$export_tables == "total") {
           
           #write lut and total
-          cat(paste0("Writing to model_analysis_lut table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_analysis_lut table...  ", "\n"))
           write_lut(con, analysis_lut)
           
-          cat(paste0("Writing to model_estimates_total table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_estimates_total table...  ", "\n"))
           write_total(con)
           
         } else if (params$export_tables == "stratum") {
           
           #write lut and stratum
-          cat(paste0("Writing to model_analysis_lut table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_analysis_lut table...  ", "\n"))
           write_lut(con, analysis_lut)
           
-          cat(paste0("Writing to model_estimates_stratum table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_estimates_stratum table...  ", "\n"))
           write_stratum(con)
           
         } else if (params$export_tables == "both") {
           
           #write lut, total, and stratum
-          cat(paste0("Writing to model_analysis_lut table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_analysis_lut table...  ", "\n"))
           write_lut(con, analysis_lut)
           
-          cat(paste0("Writing to model_estimates_total table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_estimates_total table...  ", "\n"))
           write_total(con)
           
-          cat(paste0("Writing to model_estimates_stratum table...  ","\u2713", "\n"))
+          cat(paste0("Writing to model_estimates_stratum table...  ", "\n"))
           write_stratum(con)
           
         } else {

--- a/R_functions/process_estimates_pe.R
+++ b/R_functions/process_estimates_pe.R
@@ -124,14 +124,14 @@ process_estimates_pe <- function(analysis_lut, estimates_pe) {
     
   # Catch 
   #calculate days open and days surveyed
-  totaldaysopen_totaldayssurveyed <-transformed_pe_data$pe_summarized_catch |> 
-    dplyr::distinct(period, day_type, est_cg, n_obs, N_days_open) |> 
-    dplyr::group_by(est_cg) |> 
-    dplyr::summarise(
-      totaldaysopen = sum(N_days_open),
-      totalobs = sum(n_obs),
-      .groups = 'drop'
-    )
+  # totaldaysopen_totaldayssurveyed <-transformed_pe_data$pe_summarized_catch |> 
+  #   dplyr::distinct(period, day_type, est_cg, n_obs, N_days_open) |> 
+  #   dplyr::group_by(est_cg) |> 
+  #   dplyr::summarise(
+  #     totaldaysopen = sum(N_days_open),
+  #     totalobs = sum(n_obs),
+  #     .groups = 'drop'
+  #   )
   
   #catch transformation
   transformed_pe_data$pe_summarized_catch <- transformed_pe_data$pe_summarized_catch |>
@@ -162,26 +162,26 @@ process_estimates_pe <- function(analysis_lut, estimates_pe) {
     )
   
   #prep totaldays object for joining back with pe_summarized_catch
-  totaldaysopen_totaldayssurveyed <- totaldaysopen_totaldayssurveyed |> 
-    tidyr::pivot_longer(cols = c(totaldaysopen, totalobs),
-                 names_to = "estimate_type",
-                 values_to = "value") |> 
-    dplyr::mutate(
-      analysis_id = unique(transformed_pe_data$pe_summarized_catch$analysis_id),
-      project_name = unique(transformed_pe_data$pe_summarized_catch$project_name),
-      fishery_name = unique(transformed_pe_data$pe_summarized_catch$fishery_name),
-      model_type = unique(transformed_pe_data$pe_summarized_catch$model_type),
-      #same date consideration as above
-      min_event_date = as.Date(params$est_date_start),
-      max_event_date = as.Date(
-        ifelse(
-          Sys.Date() <= params$est_date_end, Sys.Date(),
-          params$est_date_end
-        ))
-    )
+  # totaldaysopen_totaldayssurveyed <- totaldaysopen_totaldayssurveyed |> 
+  #   tidyr::pivot_longer(cols = c(totaldaysopen, totalobs),
+  #                names_to = "estimate_type",
+  #                values_to = "value") |> 
+  #   dplyr::mutate(
+  #     analysis_id = unique(transformed_pe_data$pe_summarized_catch$analysis_id),
+  #     project_name = unique(transformed_pe_data$pe_summarized_catch$project_name),
+  #     fishery_name = unique(transformed_pe_data$pe_summarized_catch$fishery_name),
+  #     model_type = unique(transformed_pe_data$pe_summarized_catch$model_type),
+  #     #same date consideration as above
+  #     min_event_date = as.Date(params$est_date_start),
+  #     max_event_date = as.Date(
+  #       ifelse(
+  #         Sys.Date() <= params$est_date_end, Sys.Date(),
+  #         params$est_date_end
+  #       ))
+  #   )
     
-  transformed_pe_data$pe_summarized_catch <- transformed_pe_data$pe_summarized_catch |> 
-    dplyr::bind_rows(totaldaysopen_totaldayssurveyed)
+  # transformed_pe_data$pe_summarized_catch <- transformed_pe_data$pe_summarized_catch |> 
+  #   dplyr::bind_rows(totaldaysopen_totaldayssurveyed)
   
   #tidy output
   transformed_pe_data$pe_summarized_catch <- transformed_pe_data$pe_summarized_catch |>

--- a/R_functions/transform_estimates.R
+++ b/R_functions/transform_estimates.R
@@ -56,6 +56,49 @@ transform_estimates <- function(dwg, transformed_pe_data, transformed_bss_data) 
       model_type == "PE" ~ params$period_pe,
       model_type == "BSS" ~ params$period_bss
     ))
+
+  ########################################################################################
+  ### Performing standardization procedures. This cleanup is needed to better align
+  ### different model outputs and in preparation for the development of a data dictionary.
+  ### These edits are a post-hoc approach and we plan to implement these changes earlier
+  ### in the pipeline during future development phases. - CH 10/9/2024
+  ########################################################################################
+
+  # purrr::map() #across stratum and total tables in creel_estimates
+  
+  x |> 
+    dplyr::mutate(
+      dplyr::case_when( #Make BSS outputs match PE
+        estimate_category = "C_daily" ~ "catch",
+        estimate_category = "E_daily" ~ "effort",
+        estimate_category = "CPUE_daily" ~ "catch_per_unit_effort"
+      ),
+      dplyr::case_when(
+        #apply snake_case to estimate_type values
+        estimate_type = "totalobs" ~ "total_observations", ### consider moving to analysis_lut
+        estimate_type = "N_days_total" ~ "n_days_open", ### consider moving to analysis_lut
+        estimate_type = "totaldaysopen" ~ "total_days_open", ### consider moving to analysis_lut
+        
+        estimate_type = "Rhat" ~ "r_hat",
+        estimate_type = "n_div" ~ "number_of_divisions",
+        estimate_type = "n_eff" ~ "number_of_draws", #https://mc-stan.org/docs/cmdstan-guide/stansummary.html
+        estimate_type = "df" ~ "degrees_of_freedom",
+        estimate_type = "sd" ~ "standard_deviation",
+        estimate_type = "se_mean", "standard_error_of_mean",
+        estimate_type = "est" ~"estimate" #applies to catch & effort, which are identified by model_type field,
+        estimate_type = "catch_est_mean" ~ "catch_estimate_mean",
+        estimate_type = "catch_est_var" ~ "catch_estimate_variance",,
+        estimate_type = "ang_hrs_mean" ~ "angler_hours_mean", #or mean_angler_hours ?
+        estimate_type = "ang_hrs_var" ~ "angler_hours_variance",
+        
+        estimate_type = "2.5_pct" ~ "lower_quantile_2_5", #maybe quantile_lower_2_5 or quantile_2_5_percent
+        estimate_type = "25_pct" ~ "lower_quantile_25",
+        estimate_type = "50_pct" ~ "median_quantile_50",
+        estimate_type = "75_pct" ~ "upper_quantile_75",
+        estimate_type = "97.5_pct" ~ "upper_quantile_97_5",
+        TRUE ~ estimate_type
+      )
+    )
   
   cat("\nTransformed output object 'creel_estimates' created.")
   

--- a/R_functions/transform_estimates.R
+++ b/R_functions/transform_estimates.R
@@ -107,22 +107,14 @@ transform_estimates <- function(dwg, transformed_pe_data, transformed_bss_data) 
   
   #Modify fields
   creel_estimates$stratum <- creel_estimates$stratum |> 
-    dplyr::mutate(
-      estimate_time_period = period_timestep, #rename
-      reporting_aggregation = "stratum") |>  #create
-    dplyr::relocate(reporting_aggregation, .after = "estimate_time_period")
+    dplyr::rename(estimate_time_period = period_timestep)
   
   creel_estimates$total <- creel_estimates$total |> 
-    dplyr::mutate(
-      estimate_time_period = period_timestep, #rename
-      reporting_aggregation = "total") |>     #create
-    dplyr::relocate(reporting_aggregation, .after = "estimate_time_period")
+    dplyr::rename(estimate_time_period = period_timestep)
   
-  
-  
-  
-  
+
   ####################################################################################
+  
   cat("\nTransformed output object 'creel_estimates' created.")
   
   return(creel_estimates)

--- a/R_functions/transform_estimates.R
+++ b/R_functions/transform_estimates.R
@@ -95,11 +95,11 @@ transform_estimates <- function(dwg, transformed_pe_data, transformed_bss_data) 
           estimate_type == "catch_est_var" ~ "catch_estimate_variance",
           estimate_type == "ang_hrs_mean" ~ "angler_hours_mean", #or mean_angler_hours ?
           estimate_type == "ang_hrs_var" ~ "angler_hours_variance",
-          estimate_type == "2.5_pct" ~ "lower_quantile_2_5", #maybe quantile_lower_2_5 or quantile_2_5_percent
-          estimate_type == "25_pct" ~ "lower_quantile_25",
-          estimate_type == "50_pct" ~ "median_quantile_50",
-          estimate_type == "75_pct" ~ "upper_quantile_75",
-          estimate_type == "97.5_pct" ~ "upper_quantile_97_5",
+          estimate_type == "2.5_pct" ~ "quantile_lower_2_5",
+          estimate_type == "25_pct" ~ "quantile_lower_25",
+          estimate_type == "50_pct" ~ "quantile_median_50",
+          estimate_type == "75_pct" ~ "quantile_upper_75",
+          estimate_type == "97.5_pct" ~ "quantile_upper_97_5",
           TRUE ~ estimate_type
         )
       )

--- a/R_functions/transform_estimates.R
+++ b/R_functions/transform_estimates.R
@@ -74,21 +74,21 @@ transform_estimates <- function(dwg, transformed_pe_data, transformed_bss_data) 
         estimate_category = dplyr::case_when( 
           estimate_category == "C_daily" ~ "catch",
           estimate_category == "E_daily" ~ "effort",
-          estimate_category == "CPUE_daily" ~ "catch_per_unit_effort",
+          estimate_category == "CPUE_daily" ~ "CPUE",
           TRUE ~ estimate_category,
         ),
         #apply snake_case to estimate_type values
         estimate_type = dplyr::case_when(
           estimate_type == "totalobs" ~ "total_observations", ### consider moving to analysis_lut
-          estimate_type == "N_days_total" ~ "n_days_open", ### consider moving to analysis_lut
+          estimate_type == "N_days_total" ~ "number_days_open", ### consider moving to analysis_lut
           estimate_type == "totaldaysopen" ~ "total_days_open", ### consider moving to analysis_lut
-          estimate_type == "n_obs" ~ "number_of_observations",
-          estimate_type == "Rhat" ~ "r_hat",
-          estimate_type == "n_div" ~ "number_of_divisions",
-          estimate_type == "n_eff" ~ "number_of_draws", #https://mc-stan.org/docs/cmdstan-guide/stansummary.html
-          estimate_type == "df" ~ "degrees_of_freedom",
+          estimate_type == "n_obs" ~ "number_observations",
+          estimate_type == "Rhat" ~ "R_hat",
+          estimate_type == "n_div" ~ "number_divisions",
+          #estimate_type == "n_eff" ~ "number_draws", #https://mc-stan.org/docs/cmdstan-guide/stansummary.html
+          estimate_type == "df" ~ "degrees_freedom",
           estimate_type == "sd" ~ "standard_deviation",
-          estimate_type == "se_mean" ~ "standard_error_of_mean",
+          estimate_type == "se_mean" ~ "standard_error_mean",
           estimate_type == "est" ~ "estimate_stratum", #applies to catch & effort, which are identified by model_type field
           estimate_type == "est_sum" ~ "estimate_sum",
           estimate_type == "catch_est_mean" ~ "catch_estimate_mean",
@@ -101,22 +101,22 @@ transform_estimates <- function(dwg, transformed_pe_data, transformed_bss_data) 
           estimate_type == "75_pct" ~ "upper_quantile_75",
           estimate_type == "97.5_pct" ~ "upper_quantile_97_5",
           TRUE ~ estimate_type
-        ),
+        )
       )
     )
   
   #Modify fields
   creel_estimates$stratum <- creel_estimates$stratum |> 
-    mutate(
+    dplyr::mutate(
       estimate_time_period = period_timestep, #rename
-      reporting_aggregation = "stratum",) |>  #create
-    relocate(reporting_aggregation, .after = "estimate_time_period")
+      reporting_aggregation = "stratum") |>  #create
+    dplyr::relocate(reporting_aggregation, .after = "estimate_time_period")
   
   creel_estimates$total <- creel_estimates$total |> 
-    mutate(
+    dplyr::mutate(
       estimate_time_period = period_timestep, #rename
       reporting_aggregation = "total") |>     #create
-    relocate(reporting_aggregation, .after = "estimate_time_period")
+    dplyr::relocate(reporting_aggregation, .after = "estimate_time_period")
   
   
   


### PR DESCRIPTION
Formatting changes to standardized naming of estimate_category and estimate_type field categorical values. Also includes updates to messaging to user and silences summary stat calculated in process_estimates_pe. Evan mentioned these updates in pull request https://github.com/wdfw-fp/CreelEstimates/pull/51#pullrequestreview-2341530796.