### PR TITLE
Fix ang_int assignment and update plot_inputs_pe_index_effort_counts

### DIFF
--- a/R_functions/plot_inputs_pe_index_effort_counts.R
+++ b/R_functions/plot_inputs_pe_index_effort_counts.R
@@ -12,13 +12,18 @@ plot_inputs_pe_index_effort_counts <- function(
 ){
 
   p <- effort_index |>
-    mutate(count_sequence = factor(count_sequence)) |> 
+    mutate(count_sequence = factor(count_sequence),
+           count_type = dplyr::case_match(
+             count_type,
+             "Trailers Only" ~ "Trailers",
+             "Vehicle Only"  ~ "Vehicles"
+           )) |> 
     ggplot(aes(event_date, count_index, fill = count_sequence)) +
     #geom_point() + geom_text(aes(label = count_index), nudge_y = 1, check_overlap = T) +
     geom_col(position = position_dodge(width = 0.7)) +
     scale_x_date("", date_breaks = "7 days", date_labels =  "%m-%d") + scale_y_continuous("") +
     scale_color_brewer(palette = "Blues", aesthetics = c("fill")) +
-    facet_wrap(~section_num + angler_final, scales = "fixed", ncol = 1, labeller = label_wrap_gen(multi_line = F))
+    facet_wrap(~section_num + count_type, scales = "fixed", ncol = 1, labeller = label_wrap_gen(multi_line = F))
   
   # Save if requested
   if (save) {

--- a/R_functions/prep_dwg_effort_index.R
+++ b/R_functions/prep_dwg_effort_index.R
@@ -57,15 +57,20 @@ if(str_detect(study_design, "tandard" )){
     ) 
 } 
 # create final object output of interest index_angler_final that summarizes index count data by section_num, event_date, count_sequence, & angler_final  
-  index_angler_final<-  
-    index_angler_groups |>  
-    dplyr::group_by(section_num, event_date, count_sequence, angler_final) |> #
-    dplyr::summarise(count_index = sum(count_quantity), .groups = "drop") |> 
-    dplyr::arrange(section_num, event_date, count_sequence) |> 
+  index_angler_final <-
+    index_angler_groups |>
+    dplyr::group_by(section_num, event_date, count_sequence, angler_final) |>
+    dplyr::summarise(count_index = sum(count_quantity), .groups = "drop") |>
+    dplyr::arrange(section_num, event_date, count_sequence) |>
     mutate(
-      fishery_name = params$fishery_name # add back fishery_name
-      , angler_final_int = as.integer(factor(angler_final)) 
-    ) |> 
+      fishery_name = params$fishery_name,
+      angler_final_int = as.integer(factor(angler_final, levels = c("total", "boat"))),
+      count_type = dplyr::case_match(
+        angler_final,
+        "total" ~ "Vehicle Only",
+        "boat"  ~ "Trailers Only"
+      )
+    ) |>
     relocate(fishery_name)
   
   return(list(index_angler_groups = index_angler_groups, index_angler_final = index_angler_final))  

--- a/R_functions/prep_inputs_pe_paired_census_index_counts.R
+++ b/R_functions/prep_inputs_pe_paired_census_index_counts.R
@@ -34,7 +34,7 @@ if(str_detect(study_design, "tandard" )){
             dplyr::group_by(section_num, event_date, count_sequence) |>
             dplyr::summarize(angler_final = "boat", count_census = sum(count_census), .groups = "drop")
         ),
-        dwg_summarized$effort_index |> select(-fishery_name, -angler_final_int)
+        dwg_summarized$effort_index |> select(-fishery_name, -angler_final_int, -count_type)
         ,
         by = c("section_num", "event_date", "count_sequence", "angler_final")
       ) |> 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -568,19 +568,9 @@ saveRDS(dwg_summ, file.path(outputs_folders$inputs, "dwg_summ.rds"))
 ```{r plot_index_effort_counts, cache=params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", fig.cap= "Index effort counts for each count sequence on surveyed days within the monitoring period. Index counts represent the sum of counts completed at each sampling site during a drive around effort count."}
 # plot of index effort counts faceted by section and count_type per count sequence and day 
 
-# rename to items actually counted 
-summarised_index_counts <- dwg_summ$effort_index |>
-  mutate(
-    angler_final = case_when(
-      angler_final == "boat" ~ "trailers",
-      angler_final == "total" ~ "vehicles",
-      TRUE ~ angler_final  # keeps any other values unchanged
-    )
-  )
-
 plot_inputs_pe_index_effort_counts(
   params = params,
-  effort_index = summarised_index_counts,
+  effort_index = dwg_summ$effort_index,
   outputs_folders = outputs_folders)
 ```
 


### PR DESCRIPTION
Corrects angler_int assignments and the angler category labels displayed in the index effort count plot. The previous assignments were incorrect, causing the plot to misrepresent effort counts across angler categories. Updates ensure values are mapped accurately and that displayed categories reflect the intended classification.
