### PR TITLE
feat: update est_pe_effort_sampled_by_interviews function to R package format, add function call to template script.

### DIFF
--- a/R_functions/est_pe_effort_sampled_by_interviews.R
+++ b/R_functions/est_pe_effort_sampled_by_interviews.R
@@ -1,88 +1,73 @@
-# Evaluate proportion of estimated total angler hours (effort) sampled during interviews, grouped by angler type
-
-# EB 7.24.2023 need to deal with repeating data over catch groups, right now multiplying total stratum fishing hours from interviews by n-number of catch groups 
-
-# example: est_pe_effort_sampled_by_interviews(days=dwg$days, dwg_summ, estimates_pe$effort)
-
+#' Estimate proportion of total angler effort sampled during interviews
+#'
+#' Evaluates the proportion of estimated total angler hours (effort) that were
+#' sampled during creel interviews, grouped by section, angler type, period,
+#' and day type. Returns a season-long summary collapsed across periods.
+#'
+#' @param days A data frame of fishing days produced by [prep_days()], containing
+#'   columns `event_date`, `period`, and `day_type`.
+#' @param dwg_summ A named list of summarized creel data frames, as produced by
+#'   the shared data aggregation steps in the analysis template. Must contain an
+#'   `interview` element with columns `interview_id`, `section_num`, `event_date`,
+#'   `angler_final`, and `fishing_time_total`.
+#' @param estimates_pe_effort A data frame of PE effort estimates, typically
+#'   `estimates_pe$effort`. Must contain columns `section_num`, `period`,
+#'   `day_type`, `angler_final`, and `est`.
+#'
+#' @return A data frame with one row per `section_num` and `angler_type`,
+#'   containing columns:
+#'   \describe{
+#'     \item{section_num}{River section identifier.}
+#'     \item{angler_type}{Angler type (renamed from `angler_final`).}
+#'     \item{interview_hours_total}{Total angler hours recorded across interviews.}
+#'     \item{angler_effort_total}{Total estimated angler effort (hours) from PE.}
+#'     \item{proportion_interviewed_effort}{Ratio of interviewed hours to total
+#'       estimated effort.}
+#'   }
+#'
+#' @export
 est_pe_effort_sampled_by_interviews <- function(
     days,
     dwg_summ,
-    estimates_pe_effort = estimates_pe$effort,
-    ...
-){
+    estimates_pe_effort
+) {
+  
+  effort_by_strata <- estimates_pe_effort |>
+    dplyr::select(section_num, period, day_type, angler_final, effort_est = est) |>
+    dplyr::group_by(section_num, period, day_type, angler_final) |>
+    dplyr::summarise(
+      angler_effort_total = sum(effort_est),
+      .groups = "drop"
+    )
   
   dwg_summ$interview |>
-    distinct(interview_id, section_num, event_date, angler_final, fishing_time_total) |> # ensure only distinct interviews are evaluated, given potentially > 1 catch groups
-    left_join(days |> dplyr::select(event_date, period, day_type), by = "event_date") |> 
-    drop_na(angler_final) |>  
-    group_by(period, section_num, day_type, angler_final) |> 
-    summarise(
-      interview_hours_total = sum(fishing_time_total)
-    ) |> 
-    # left_join(estimates_pe$effort |> ## join expanded catch estimates in pe$est_effort_s_ts_dt_at to total angler hours from interviews in pe$interview 
-    left_join(estimates_pe_effort |> 
-                select(section_num, period, section_num, day_type, angler_final, effort_est = est) |>
-                group_by(section_num, period, day_type, angler_final) |> 
-                summarise(
-                  angler_effort_total = sum(effort_est))
-              , 
-              by = c("section_num", "period", "day_type", "angler_final")) |>
-    mutate(
-      angler_effort_total = if_else(is.nan(angler_effort_total), 0 , angler_effort_total) # coerce to zero rows where bank effort not estimable due
-      # to method of obtaining bank anglers from total - boat, circle back on this with KB at some point
-    ) |> 
-    group_by(section_num, angler_final) |> 
-    summarise(
+    dplyr::distinct(interview_id, section_num, event_date, angler_final, fishing_time_total) |>
+    dplyr::left_join(
+      dplyr::select(days, event_date, period, day_type),
+      by = "event_date"
+    ) |>
+    tidyr::drop_na(angler_final) |>
+    dplyr::group_by(period, section_num, day_type, angler_final) |>
+    dplyr::summarise(
+      interview_hours_total = sum(fishing_time_total),
+      .groups = "drop"
+    ) |>
+    dplyr::left_join(
+      effort_by_strata,
+      by = c("section_num", "period", "day_type", "angler_final")
+    ) |>
+    dplyr::mutate(
+      # Coerce NaN to zero for strata where bank effort is not directly estimable
+      # (derived as total minus boat effort); revisit with KB
+      angler_effort_total = dplyr::if_else(is.nan(angler_effort_total), 0, angler_effort_total)
+    ) |>
+    dplyr::group_by(section_num, angler_final) |>
+    dplyr::summarise(
       interview_hours_total = sum(interview_hours_total),
-      angler_effort_total = sum(angler_effort_total),
-      proportion_interviewed_effort = (interview_hours_total / angler_effort_total)
-    ) |> 
-    gt(groupname_col = "section_name") |> 
-    fmt_number(c(interview_hours_total, angler_effort_total, proportion_interviewed_effort), decimals = 2)
-  # |>
-  #   bind_rows(
-  #     dwg_summ$interview |>
-  #       left_join(dwg$days |> dplyr::select(event_date, period, day_type), by = "event_date") |> 
-  #       drop_na(angler_final) |>  
-  #       group_by(period, section_num, day_type, angler_final) |> 
-  #       summarise(
-  #         interview_hours_total = sum(fishing_time_total)
-  #       ) |> 
-  #       left_join(estimates_pe$effort |> ## join expanded catch estimates in pe$est_effort_s_ts_dt_at to total angler hours from interviews in pe$interview 
-  #                   select(section_num, period, section_num, day_type, angler_final, effort_est = est) |>
-  #                   group_by(section_num, period, day_type, angler_final) |> 
-  #                   summarise(
-  #                     angler_effort_total = sum(effort_est))
-  #                 , 
-  #                 by = c("section_num", "period", "day_type", "angler_final")) |> 
-  #       group_by(section_num) |> 
-  #       summarise(
-  #         interview_hours_total = sum(interview_hours_total),
-  #         angler_effort_total = sum(angler_effort_total),
-  #         proportion_interviewed_effort = (interview_hours_total / angler_effort_total)
-  #       ) 
-  #     |> 
-  #       mutate(
-  #         angler_final = "total",
-  #         angler_effort_total = if_else(is.nan(angler_effort_total), 0 , angler_effort_total) # Again, coerce to zero rows where bank effort not estimable due
-  #         # to method of obtaining bank anglers from total - boat, circle back on this with KB at some point
-  #       )
-  #   ) |>
-  #   mutate(across(where(is.numeric), round, 2)) |>
-  #   left_join(
-  #     dwg$interview |> distinct(fishing_location, section_num),
-  #     by = "section_num") |>
-  #   gt(groupname_col = "section_name") |>
-  #   cols_label(
-  #     angler_final = md("angler type"),
-  #     interview_hours_total = md("total angler hours from direct sampling (interviews)"),
-  #     angler_effort_total = md("total angler hours from expanded effort estimates"),
-  #     proportion_interviewed_effort = md("proportion of total effort sampled in interviews")
-  #   ) |>
-  #   tab_header(
-  #     title = md("Estimated total angler effort sampled during interviews"),
-  #     subtitle = md("The season-long total of angler hours from interviews and effort counts. The fifth column displays the estimated proportion of total angling effort (angler hours) that was directly sampled during creel interviews.")) |>
-  #   tab_options(container.overflow.x = T, container.overflow.y = T)
-
+      angler_effort_total   = sum(angler_effort_total),
+      proportion_interviewed_effort = interview_hours_total / angler_effort_total,
+      .groups = "drop"
+    ) |>
+    dplyr::rename(angler_type = angler_final)
   
 }

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1371,9 +1371,11 @@ map_df(estimates_bss, ~.x$overview) |>
 
 ```{r effort_sampled_by_interviews, eval=TRUE, cache=params$enable_cache, dependson=c("dwg_fetch", "prep_dwg_summ_shared_summary_objects", "estimates_pe"), cache.extra=param_hash}
 
-est_pe_effort_sampled_by_interviews(
-  days = dwg$days, dwg_summ = dwg_summ, estimates_pe_effort = estimates_pe$effort
-) |> 
+interview_coverage_table <-  est_pe_effort_sampled_by_interviews(
+  days = dwg$days, 
+  dwg_summ = dwg_summ, 
+  estimates_pe_effort = estimates_pe$effort
+  ) |> 
   gt() |> 
     grand_summary_rows(
       columns = c(interview_hours_total, angler_effort_total),
@@ -1414,6 +1416,12 @@ est_pe_effort_sampled_by_interviews(
         cells_grand_summary()
       )
     )
+
+interview_coverage_table
+
+# Save to figures folder
+save_gt_table(interview_coverage_table, paste0("interview_coverage_table"))
+
 ```
 
 # Save results

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1374,17 +1374,46 @@ map_df(estimates_bss, ~.x$overview) |>
 est_pe_effort_sampled_by_interviews(
   days = dwg$days, dwg_summ = dwg_summ, estimates_pe_effort = estimates_pe$effort
 ) |> 
-  gt(groupname_col = "section_name") |> 
-  fmt_number(c(interview_hours_total, angler_effort_total, proportion_interviewed_effort), decimals = 0) |> 
-  fmt_number(proportion_interviewed_effort, decimals = 2) |> 
-  cols_label_with(
-    fn = ~str_to_sentence(str_replace_all(.x, "_", " "))
-  ) |>
-  tab_header(title = "Summation of interview hours, total PE estimated effort (angler hours), and the estimated proportion of total effort that was sampled during creel surveys.") |>
-  tab_options(
-    heading.title.font.size = px(14),
-    table.font.color = "black"
-  )
+  gt() |> 
+    grand_summary_rows(
+      columns = c(interview_hours_total, angler_effort_total),
+      fns = list(Total = ~sum(.)),
+      fmt = ~fmt_number(., decimals = 0, use_seps = TRUE)
+    ) |>
+    grand_summary_rows(
+      columns = c(proportion_interviewed_effort),
+      fns = list(Total = ~sum(interview_hours_total) / sum(angler_effort_total)),
+      fmt = ~fmt_percent(., decimals = 1)
+    ) |> 
+    fmt_number(c(interview_hours_total, angler_effort_total), decimals = 0) |> 
+    fmt_percent(proportion_interviewed_effort, decimals = 1) |> 
+    cols_width(
+      section_num ~ px(100),
+      angler_type ~ px(80),
+      interview_hours_total ~ px(120),
+      angler_effort_total ~ px(100),
+      proportion_interviewed_effort ~ px(150)
+    ) |> 
+    cols_label(
+      section_num = "Section number",
+      angler_type = "Angler type",
+      interview_hours_total = "Angler hours from interviews",
+      angler_effort_total = "Angler hours from expanded estimates",
+      proportion_interviewed_effort = "Interview coverage (%)"
+    ) |> 
+    tab_caption(caption = "Percentage of total estimated angler effort (angler hours) that was directly sampled through creel interviews, by section and angler type.") |>
+    tab_options(
+      heading.title.font.size = px(14),
+      table.font.color = "black"
+    ) |> 
+    tab_style(
+      style = cell_text(align = "center"),
+      locations = list(
+        cells_column_labels(columns = everything()),
+        cells_body(columns = everything()),
+        cells_grand_summary()
+      )
+    )
 ```
 
 # Save results

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1093,7 +1093,8 @@ overview_combined <- purrr::imap_dfr(
 # Create a gt table with row groups
 overview_combined |> 
   gt(groupname_col = "catch_group") |>
-  fmt_number(-c(estimate, est_cg, catch_group), decimals = 1) |> 
+  fmt_number(-c(estimate, est_cg, catch_group, Rhat), decimals = 1) |> 
+  fmt_number(Rhat, decimals = 2) |> 
   tab_style(
     style = cell_fill(),
     locations = cells_body(columns = "50%")
@@ -1360,9 +1361,30 @@ map_df(estimates_bss, ~.x$overview) |>
     table.font.color = "black"
   ) |> 
   fmt_number(-c(estimate, est_cg), decimals = 1) |> 
+  fmt_number(Rhat, decimals = 2) |> 
   tab_style(style = cell_fill(), locations = cells_body(columns = "PE")) |> 
   tab_style(style = cell_fill(), locations = cells_body(columns = "50%"))
 
+```
+
+## Estimated total effort sampled by interviews
+
+```{r effort_sampled_by_interviews, eval=TRUE, cache=params$enable_cache, dependson=c("dwg_fetch", "prep_dwg_summ_shared_summary_objects", "estimates_pe"), cache.extra=param_hash}
+
+est_pe_effort_sampled_by_interviews(
+  days = dwg$days, dwg_summ = dwg_summ, estimates_pe_effort = estimates_pe$effort
+) |> 
+  gt(groupname_col = "section_name") |> 
+  fmt_number(c(interview_hours_total, angler_effort_total, proportion_interviewed_effort), decimals = 0) |> 
+  fmt_number(proportion_interviewed_effort, decimals = 2) |> 
+  cols_label_with(
+    fn = ~str_to_sentence(str_replace_all(.x, "_", " "))
+  ) |>
+  tab_header(title = "Summation of interview hours, total PE estimated effort (angler hours), and the estimated proportion of total effort that was sampled during creel surveys.") |>
+  tab_options(
+    heading.title.font.size = px(14),
+    table.font.color = "black"
+  )
 ```
 
 # Save results


### PR DESCRIPTION
## Summary
Refactors `est_pe_effort_sampled_by_interviews()` for R package compatibility and integrates it into the `fw_creel.Rmd` analysis template.

## Changes
- Adds roxygen2 documentation (`@param`, `@return`, `@export`)
- Removes unused `...` argument and fragile calling-environment default for `estimates_pe_effort`
- Extracts intermediate `effort_by_strata` object for readability; removes duplicate `section_num` in `select()`
- Adds `.groups = 'drop'` to all `summarise()` calls; moves `proportion_interviewed_effort` into final `summarise()`
- Applies explicit `dplyr::`/`tidyr::` namespacing throughout
- Removes commented-out legacy code
- Adds call in `fw_creel.Rmd` PE estimation section, enabling easy lookup of effort sampling rates by angler type and section