### PR TITLE
Fix/align bss pe effort census aggregation

### DIFF
--- a/R_functions/plot_inputs_pe_census_vs_index.R
+++ b/R_functions/plot_inputs_pe_census_vs_index.R
@@ -18,8 +18,9 @@ plot_inputs_pe_census_vs_index <- function(
     labs(fill = "Angler type") +
     scale_color_brewer(palette = "Blues", aesthetics = c("fill")) +
     geom_smooth(method = "lm", se = FALSE) +
-    guides(fill = guide_legend(override.aes = list(linetype = 0))) +
-    facet_wrap(~paste("Section:",section_num), labeller = label_wrap_gen(multi_line = F))
+    guides(fill = guide_legend(override.aes = list(linetype = 0))) 
+  # +
+    # facet_wrap(~paste("Section:",section_num), labeller = label_wrap_gen(multi_line = F))
   
   # Save if requested
   if (save) {

--- a/R_functions/prep_inputs_pe_ang_hrs.R
+++ b/R_functions/prep_inputs_pe_ang_hrs.R
@@ -83,10 +83,10 @@ prep_inputs_pe_ang_hrs <- function(
     left_join(
       angler_hours_daily_mean
       , 
-      paired_census_index_counts |> dplyr::select(angler_final, TI_expan_final)
+      paired_census_index_counts |> dplyr::select(angler_final, section_num, TI_expan_final)
       # census_TI_expan |> dplyr::select(section_num, angler_final, TI_expan_final)
       ,
-      by = c("angler_final")
+      by = c("angler_final", "section_num")
     ) |>
     mutate(
       ang_hrs_daily_mean_TI_expan = angler_hours_daily_mean * TI_expan_final

--- a/R_functions/prep_inputs_pe_ang_hrs.R
+++ b/R_functions/prep_inputs_pe_ang_hrs.R
@@ -83,10 +83,10 @@ prep_inputs_pe_ang_hrs <- function(
     left_join(
       angler_hours_daily_mean
       , 
-      paired_census_index_counts |> dplyr::select(section_num, angler_final, TI_expan_final)
+      paired_census_index_counts |> dplyr::select(angler_final, TI_expan_final)
       # census_TI_expan |> dplyr::select(section_num, angler_final, TI_expan_final)
       ,
-      by = c("section_num", "angler_final")
+      by = c("angler_final")
     ) |>
     mutate(
       ang_hrs_daily_mean_TI_expan = angler_hours_daily_mean * TI_expan_final

--- a/R_functions/prep_inputs_pe_paired_census_index_counts.R
+++ b/R_functions/prep_inputs_pe_paired_census_index_counts.R
@@ -93,12 +93,12 @@ if(str_detect(study_design, "tandard" )){
     
     census_TI_expan <- 
       census_TI_expan |> 
-      dplyr::group_by(section_num, angler_final) |>
+      dplyr::group_by(angler_final) |>
       dplyr::summarise(
         dplyr::across(c(count_census, count_index), sum),
         .groups = "drop"
       ) |>
-      dplyr::left_join(census_expan, by = c("section_num", "angler_final")) |>
+      dplyr::left_join(census_expan, by = c("angler_final")) |>
       dplyr::mutate(
         TI_expan_weighted = count_census / count_index,
         TI_expan_weighted = if_else(

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -24,7 +24,7 @@ params:
   data_grade: "provisional"
   export: "local"
   export_tables: "both"
-  enable_cache: TRUE  # Set to FALSE to disable all caching (useful when cached files become too large)
+  enable_cache: FALSE  # Set to FALSE to disable all caching (useful when cached files become too large)
 output:
   html_document:
     toc: true
@@ -651,9 +651,9 @@ saveRDS(inputs_pe, file.path(outputs_folders$inputs, "inputs_pe.rds"))
 
 # table view of census / index surveys and resulting bias term ratio 
 inputs_pe$paired_census_index_counts |> 
-  select(section_num, angler_final, count_census, count_index, TI_expan_final) |> 
+  distinct(angler_final, count_census, count_index, TI_expan_final) |> 
   gt() |> 
-tab_header(
+  tab_header(
     title = "The season-long sum of paired census and index angler effort counts and corresponding bias-term ratio (TI_expan_final), indicating the magnitude and direction (postive or negative) of bias in index counts relative to census counts."
   ) |>
   tab_options(

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -5,7 +5,7 @@ params:
   project_name: "District 14"
   fishery_name: "Skagit fall salmon 2024"
   est_date_start: "2024-09-01"
-  est_date_end: "2024-09-15"
+  est_date_end: "2024-09-30"
   est_catch_groups: !r data.frame(rbind(
     c(species = 'Coho', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
     c(species = 'Coho', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))


### PR DESCRIPTION
## Fix: Align census-index effort aggregation between PE and BSS

The PE was computing the census-index bias term (TI expansion factor) at the section level, but BSS consumes it at the fishery-wide level. This mismatch meant the two models were operating on inconsistent effort inputs. This PR brings them into alignment by aggregating census and index counts across all sections before computing the bias term.

### Changes

- **`prep_inputs_pe_paired_census_index_counts.R`** — Removed `section_num` from `group_by()` and corresponding join so TI expansion is computed fishery-wide, matching BSS expectations.
- **`prep_inputs_pe_ang_hrs.R`** — Updated join to reflect the new fishery-wide structure.
- **`plot_inputs_pe_census_vs_index.R`** — Removed section faceting from the census vs. index plot (no longer meaningful).
- **`fw_creel.Rmd`** — Used `distinct()` in the bias-term summary table to drop duplicated rows that arose from the aggregation level change; minor param/formatting cleanup.