### PR TITLE
fix: respect enable_cache param - ensure caching and .cache folder are only used/generated based on param

### DIFF
--- a/R_functions/setup_analysis_structure.R
+++ b/R_functions/setup_analysis_structure.R
@@ -37,25 +37,35 @@ setup_analysis_structure <- function(params, analysis_lut) {
     }
   })
   
-  # Define and create separate cache location
+  # Define cache location (only create folder if caching is enabled)
   cache_path <- file.path(analysis_folder_path, ".cache")
   
-  if (!dir.exists(cache_path)) {
-    dir.create(cache_path, recursive = TRUE)
+  if (isTRUE(params$enable_cache)) {
+    if (!dir.exists(cache_path)) {
+      dir.create(cache_path, recursive = TRUE)
+    }
+    
+    # Set knitr cache to SEPARATE location from analysis outputs
+    knitr::opts_chunk$set(
+      cache = TRUE,
+      cache.path = paste0(cache_path, .Platform$file.sep),
+      fig.path = paste0(outputs_folders$figures, .Platform$file.sep),
+      fig.keep = "all",
+      dev = c("png", "pdf"),
+      dpi = 300,
+      cache.extra = list(params, analysis_lut$analysis_id),
+      cache.lazy = FALSE
+    )
+  } else {
+    # Caching disabled - no .cache folder created, no cache options set
+    knitr::opts_chunk$set(
+      cache = FALSE,
+      fig.path = paste0(outputs_folders$figures, .Platform$file.sep),
+      fig.keep = "all",
+      dev = c("png", "pdf"),
+      dpi = 300
+    )
   }
-  
-  # Set knitr cache to SEPARATE location from analysis outputs
-  # Use paste0 with trailing slash for cross-platform compatibility
-  knitr::opts_chunk$set(
-    cache = TRUE,
-    cache.path = paste0(cache_path, .Platform$file.sep),
-    fig.path = paste0(outputs_folders$figures, .Platform$file.sep),
-    fig.keep = "all",
-    dev = c("png", "pdf"),
-    dpi = 300,
-    cache.extra = list(params, analysis_lut$analysis_id),
-    cache.lazy = FALSE
-  )
   
   # Set output directory for knitted HTML
   knitr::opts_chunk$set(output_dir = analysis_folder_path)
@@ -64,7 +74,11 @@ setup_analysis_structure <- function(params, analysis_lut) {
   cli::cli_alert_info("  Inputs: {.path {outputs_folders$inputs}}")
   cli::cli_alert_info("  Outputs: {.path {outputs_folders$outputs}}")
   cli::cli_alert_info("  Figures: {.path {outputs_folders$figures}}")
-  cli::cli_alert_info("  Cache: {.path {cache_path}}")
+  if (isTRUE(params$enable_cache)) {
+    cli::cli_alert_info("  Cache: {.path {cache_path}}")
+  } else {
+    cli::cli_alert_warning("  Cache: DISABLED (no .cache folder created)")
+  }
   
   # Return outputs folders for use in subsequent code
   return(list(

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -3,12 +3,12 @@ title: "Freshwater Creel Report <br>`r params$fishery_name`"
 date: "`r Sys.Date()`"
 params:
   project_name: "District 14"
-  fishery_name: "Skagit fall salmon 2024"
-  est_date_start: "2024-09-01"
-  est_date_end: "2024-09-30"
+  fishery_name: "Skagit spring Chinook upper 2025"
+  est_date_start: "2025-09-01"
+  est_date_end: "2025-09-30"
   est_catch_groups: !r data.frame(rbind(
-    c(species = 'Coho', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
-    c(species = 'Coho', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
+    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
+    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
   study_design: "Standard"   
   boat_type_collapse: "Yes"
   fish_location_determines_type: "No"
@@ -698,7 +698,7 @@ saveRDS(estimates_pe, file.path(outputs_folders$outputs, "estimates_pe.rds"))
 ```
 
 ### Effort estimates
-```{r pe_effort_summary, cache.extra=param_hash}
+```{r pe_effort_summary, cache=params$enable_cache, cache.extra=param_hash}
 # effort by section_num
 estimates_pe$effort |>
   group_by(section_num, angler_final) |> 


### PR DESCRIPTION
## Fix: `enable_cache` parameter now strictly controls caching behavior

### Problem
When `enable_cache: FALSE` was set in the YAML params, caching still occurred because `setup_analysis_structure()` unconditionally set `cache = TRUE` globally via `knitr::opts_chunk$set()`, overriding the param. The `.cache` folder was also always created regardless of the setting.

### Changes
- **`R_functions/setup_analysis_structure.R`**: Conditional logic now gates both the `.cache` folder creation and all cache-related knitr options on `params$enable_cache`. When `FALSE`, no folder is created and `cache = FALSE` is set globally.
- **`template_scripts/fw_creel.Rmd`**: Added explicit `cache=params$enable_cache` to the `pe_effort_summary` chunk, which previously inherited the (incorrectly forced-on) global default.