### PR TITLE
fix/ ensure that option to use p_TI values of 1 hard coded in database works in absence of census counts 

### DIFF
--- a/R_functions/prep_dwg_census_expan.R
+++ b/R_functions/prep_dwg_census_expan.R
@@ -11,7 +11,7 @@ prep_dwg_census_expan <- function(
   
   eff |> 
     dplyr::filter( # filter to only dates specified in params and described in dwg$days object
-      location_type == "Section",
+      location_type == "Site",
       event_date >= min(days$event_date),
       event_date <= max(days$event_date)
     ) |> 

--- a/R_functions/prep_inputs_pe_paired_census_index_counts.R
+++ b/R_functions/prep_inputs_pe_paired_census_index_counts.R
@@ -17,6 +17,9 @@ if(str_detect(study_design, "tandard" )){
         section_num = dwg_summarized$effort_index |> distinct(section_num) |> pull(), 
         angler_final = dwg_summarized$effort_index |> distinct(angler_final)|> pull(),
         TI_expan_final = 1 # If no census counts counted, this hard codes the spatial expansion to be 1 (i.e., assumes bias parameter is 1); should revisit later
+      ) |> 
+      mutate(
+        angler_final = str_replace(angler_final, "^total$", "bank")
       )
   } else {
     #begin census expansion values object by joining census and index in terms of total & boat

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -513,13 +513,13 @@ tab_style(
   # 2.1 - Aggregate index effort counts over locations within count_seq & section; count_types are converted to angler_final based on arguments
 
   # left join p_census_bank and p_census_boat p_TI values to effort index and census data so this data can be used in situations where census counts have not ocurred yet
-dwg$effort <- dwg$effort |>
+  dwg$effort <- dwg$effort |>
       select(-p_census_bank, -p_census_boat) |>
       left_join(
         dwg$fishery_manager |>
           filter(!is.na(p_census_bank) | !is.na(p_census_boat)) |>
-          distinct(section_num, surveyor_num, p_census_bank, p_census_boat),
-        by = c("section_num", "surveyor_num")
+          distinct(section_num, p_census_bank, p_census_boat),
+        by = c("section_num")
       )
     
       effort_index_summ <- 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -3,12 +3,12 @@ title: "Freshwater Creel Report <br>`r params$fishery_name`"
 date: "`r Sys.Date()`"
 params:
   project_name: "District 14"
-  fishery_name: "Skagit fall salmon 2024"
-  est_date_start: "2024-09-01"
-  est_date_end: "2024-09-30"
+  fishery_name: "Skagit spring Chinook 2026 upper"
+  est_date_start: "2026-05-16"
+  est_date_end: "2026-05-25"
   est_catch_groups: !r data.frame(rbind(
-    c(species = 'Coho', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
-    c(species = 'Coho', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
+    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
+    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
   study_design: "Standard"   
   boat_type_collapse: "Yes"
   fish_location_determines_type: "No"
@@ -511,6 +511,17 @@ tab_style(
 
 # 2.) Effort index data summarization
   # 2.1 - Aggregate index effort counts over locations within count_seq & section; count_types are converted to angler_final based on arguments
+
+  # left join p_census_bank and p_census_boat p_TI values to effort index and census data so this data can be used in situations where census counts have not ocurred yet
+dwg$effort <- dwg$effort |>
+      select(-p_census_bank, -p_census_boat) |>
+      left_join(
+        dwg$fishery_manager |>
+          filter(!is.na(p_census_bank) | !is.na(p_census_boat)) |>
+          distinct(section_num, surveyor_num, p_census_bank, p_census_boat),
+        by = c("section_num", "surveyor_num")
+      )
+    
       effort_index_summ <- 
         prep_dwg_effort_index(
           params = params,
@@ -649,26 +660,28 @@ saveRDS(inputs_pe, file.path(outputs_folders$inputs, "inputs_pe.rds"))
 
 ```{r view_paired_census_index_counts, cache=params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_pe")}
 
-# table view of census / index surveys and resulting bias term ratio 
-inputs_pe$paired_census_index_counts |> 
-  distinct(angler_final, count_census, count_index, TI_expan_final) |> 
-  gt() |> 
-  tab_header(
-    title = "The season-long sum of paired census and index angler effort counts and corresponding bias-term ratio (TI_expan_final), indicating the magnitude and direction (postive or negative) of bias in index counts relative to census counts."
-  ) |>
-  tab_options(
-    heading.title.font.size = px(14),
-    table.font.color = "black"
-  ) |> 
-  fmt_number(count_index, decimals = 0) |> 
-  fmt_number(TI_expan_final, decimals = 2)
+if (nrow(dwg_summ$effort_census) > 0) {
+  # table view of census / index surveys and resulting bias term ratio 
+  inputs_pe$paired_census_index_counts |> 
+    gt() |> 
+    tab_header(
+      title = "The season-long sum of paired census and index angler effort counts and corresponding bias-term ratio (TI_expan_final), indicating the magnitude and direction (postive or negative) of bias in index counts relative to census counts."
+    ) |>
+    tab_options(
+      heading.title.font.size = px(14),
+      table.font.color = "black"
+    ) |> 
+    fmt_number(TI_expan_final, decimals = 2)
+}
 
 ```
 
 ```{r scatterplot_census_v_index, fig.cap= "Scatterplot displaying the effort bias-term ratio (TI_expan_final) for each section and angler type (angler_final), representing the total count from census surveys divided by the total count from index surveys. A 1:1 relationship is shown by the dashed line.", dependson=c("establish_file_structure", "prep_inputs_pe")}
 
-plot_inputs_pe_census_vs_index(census_TI_expan = inputs_pe$paired_census_index_counts) +
- theme(plot.caption = element_text(size = 10, hjust = 0))
+if (nrow(dwg_summ$effort_census) > 0) {
+  plot_inputs_pe_census_vs_index(census_TI_expan = inputs_pe$paired_census_index_counts) +
+    theme(plot.caption = element_text(size = 10, hjust = 0))
+}
 
 ```
 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -671,7 +671,8 @@ if (nrow(dwg_summ$effort_census) > 0) {
       heading.title.font.size = px(14),
       table.font.color = "black"
     ) |> 
-    fmt_number(TI_expan_final, decimals = 2)
+    fmt_number(c(TI_expan_weighted, TI_expan_final), decimals = 2) |> 
+    fmt_number(c(count_census, count_index), decimals = 0)
 } else {
   gt(data.frame(
     msg = "No census effort count data was detected. Substituting a 1.0 census-index bias ratio for each section and angler type combination. This assumes there is no systematic bias in the index effort data relative to census counts."

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -672,8 +672,12 @@ if (nrow(dwg_summ$effort_census) > 0) {
       table.font.color = "black"
     ) |> 
     fmt_number(TI_expan_final, decimals = 2)
+} else {
+  gt(data.frame(
+    msg = "No census effort count data was detected. Substituting a 1.0 census-index bias ratio for each section and angler type combination. This assumes there is no systematic bias in the index effort data relative to census counts."
+  )) |>
+  tab_options(column_labels.hidden = TRUE, table.font.size = gt::px(14), table.font.color = "black")
 }
-
 ```
 
 ```{r scatterplot_census_v_index, fig.cap= "Scatterplot displaying the effort bias-term ratio (TI_expan_final) for each section and angler type (angler_final), representing the total count from census surveys divided by the total count from index surveys. A 1:1 relationship is shown by the dashed line.", dependson=c("establish_file_structure", "prep_inputs_pe")}


### PR DESCRIPTION
ensure that option to use p_TI values of 1 hard coded in database works in absence of census counts for effort bias correction, minor edits to template .Rmd, prep_dwg_census_expan.R and prep_inputs_pe_paired_census_index_counts.R. Added if wrappers so that plots and tables depending on census counts aren't run if there are no census counts to prevent error. 