### PR TITLE
Dynamic fishery date params sourced from database, compatible with in-season automation

### DIFF
--- a/R_functions/resolve_dates.R
+++ b/R_functions/resolve_dates.R
@@ -1,0 +1,92 @@
+#' Resolve the estimation window for a fishery
+#'
+#' Dynamically source fishery start and end dates from the Postgres creel database.
+#' By default the script parameters est_date_start and est_date_end are blank
+#' quotes (""). Users can optionally enter one or both dates manually. Manually
+#' entered dates always override and validation of manual dates is up to the user. 
+#' If at least one date parameter is left blank, the creel database fishery lookup
+#' table (fishery_lut) is queried. See @details for more information about 
+#' database connectivity. For in-season estimates, the end date is capped at
+#' `today - 1` (i.e., yesterday, the last completed day). Aborts on a 
+#' failed/ambiguous lookup or an inverted timeframe window.
+#' 
+#' @details
+#' The `conn` argument may optionally be used to pass through an open connection
+#' to the Postgres creel database. If left as NULL (default), a connection to the
+#' database is opened internally by `creelutils::fishery_lut(conn)` and closed on exit.
+#'
+#' @param fishery character; must match a fishery_lut row when a date is blank
+#' @param est_date_start,est_date_end "YYYY-MM-DD" or "" (blank -> from the lookup table)
+#' @param conn A valid database connection from `creelutils::connect_creel_db()`. Optional argument with NULL default. If a connection is not passed through, `creelutils::fishery_lut()` internally opens a lazy connection and closes on exit.
+#' @return list(est_date_start, est_date_end), character "YYYY-MM-DD"
+#' @examples
+#' \dontrun{
+#' # standard use
+#' est_dates <- resolve_dates(params$fishery_name, params$est_date_start, params$est_date_end)
+#' 
+#' # pass open connection; for example, to the 'test' server environment
+#' con <- creelutils::connect_creel_db(db_env = "test")
+#' est_dates <- resolve_dates(params$fishery_name, params$est_date_start, params$est_date_end, conn = con)
+#' }
+resolve_dates <- function(
+    fishery,
+    est_date_start,
+    est_date_end,
+    conn = NULL
+) {
+  # If fishery dates are manually entered -> pass through unchanged
+  # If fishery dates are not entered (param as NULL, NA, length-0, or empty quotes "") -> normalize each to ""
+  coerce_blank <- \(x) if (is.null(x) || length(x) != 1 || is.na(x) || !nzchar(x)) "" else as.character(x)
+  est_start_input <- coerce_blank(est_date_start)
+  est_end_input   <- coerce_blank(est_date_end)
+  
+  # Source fishery dates from the database if either param was left blank (default: "")
+  needs_db <- !nzchar(est_start_input) || !nzchar(est_end_input)
+  
+  if (needs_db) {
+    fishery_row <- tryCatch(
+      creelutils::fishery_lut(conn = conn) |> # query and format
+        dplyr::filter(fishery_name == fishery) |>
+        dplyr::select(fishery_name, fishery_start_date, fishery_end_date),
+      error = \(e) NULL
+    )
+    
+    # NULL returned means a connection issue
+    # row count != 1 means fishery name either absent from, or duplicated in, fishery_lut
+    if (is.null(fishery_row) || nrow(fishery_row) != 1) {
+      reason <- if (is.null(fishery_row)) "lookup failed (DB connection or query error)"
+      else if (nrow(fishery_row) == 0) "fishery_name not found in fishery_lut"
+      else "fishery_name matched multiple rows in fishery_lut"
+      cli::cli_abort(c(
+        "Cannot resolve estimation window for {.val {fishery}}.",
+        "x" = "{reason},",
+        "x" = "and no manual est_date_start / est_date_end were supplied."
+      ))
+    }
+    
+    # Resolve fishery dates
+    # If the YAML param est_date_start is provided use that date (default is ""),
+    # otherwise use the start date from the fishery lookup table.
+    resolved_start <- if (nzchar(est_start_input)) as.Date(est_start_input) else as.Date(fishery_row$fishery_start_date)
+    
+    # If the YAML param est_date_end is provided use that date (default is "").
+    # If a manual est_date_end is not provided, use whichever comes first:
+    #   1) the end date from the fishery lookup table, or 2) the system date minus one (yesterday).
+    #
+    #   This accounts for in-season versus post-season runs of the script:
+    #   - run within the fishery date range (in-season)  -> uses Sys.Date() - 1
+    #   - run after the fishery has closed (post-season) -> uses the lookup table end date
+    resolved_end <- if (nzchar(est_end_input)) as.Date(est_end_input) else min(as.Date(fishery_row$fishery_end_date), Sys.Date() - 1)  
+  
+    # Abort when the resolved window is inverted
+    if (resolved_end < resolved_start) {
+      cli::cli_abort("Invalid date range for {.val {fishery}}: end ({resolved_end}) is before start ({resolved_start}).")
+    }
+  } else {
+    # Both supplied = verbatim, convert to date to validate format and mirror needs_db date resolution
+    resolved_start <- as.Date(est_start_input)
+    resolved_end   <- as.Date(est_end_input)
+  }
+  # Return list of resolved start and end dates
+  list(est_date_start = as.character(resolved_start), est_date_end = as.character(resolved_end))
+}

--- a/R_functions/setup_analysis_structure.R
+++ b/R_functions/setup_analysis_structure.R
@@ -4,9 +4,10 @@
 #' 
 #' @param params List of parameters from Rmd YAML header
 #' @param analysis_lut Analysis lookup table with folder information
+#' @param est_dates Estimate dates resolved from the database fishery lookup table or manually entered by a user
 #' 
 #' @return List with paths to outputs folders
-setup_analysis_structure <- function(params, analysis_lut) {
+setup_analysis_structure <- function(params, analysis_lut, est_dates) {
   
   # Define analysis folder path
   analysis_folder_path <- here::here(
@@ -53,7 +54,7 @@ setup_analysis_structure <- function(params, analysis_lut) {
       fig.keep = "all",
       dev = c("png", "pdf"),
       dpi = 300,
-      cache.extra = list(params, analysis_lut$analysis_id),
+      cache.extra = list(params, analysis_lut$analysis_id, est_dates),
       cache.lazy = FALSE
     )
   } else {

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -196,7 +196,7 @@ rstan_options(auto_write = TRUE)
 theme_set(theme_light()) #ggplot theme
 
 # Create hash for cache invalidation when params change
-param_hash <- digest::digest(params)
+param_hash <- digest::digest(list(params, est_dates))
 
 # Display cache status
 if (params$enable_cache) {
@@ -265,7 +265,7 @@ cli_alert_info("Identifier: {.val {analysis_lut$identifier}}")
 
 # Create analysis folder structure and configure knitr
 # THIS will set the cache.path and fig.path correctly
-analysis_structure <- setup_analysis_structure(params, analysis_lut)
+analysis_structure <- setup_analysis_structure(params, analysis_lut, est_dates)
 
 # Extract paths for use in subsequent chunks
 analysis_folder_path <- analysis_structure$analysis_folder_path

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -77,72 +77,16 @@ library(creelutils)
 ```
 
 ```{r resolve_dates, message=FALSE}
-# Resolve est_date_start / est_date_end for both interactive and headless runs.
-# Manual YAML dates win; blanks are sourced from the fishery lookup table,
-# with the end date capped at 'yesterday' for in-season runs.
+# Dynamically source fishery start and end dates from the Postgres creel database.
+# Manually entered dates always override and validation of manual dates is up to the user.
 
-# If fishery dates are manually entered -> pass through unchanged
-# If fishery dates are not entered (param as NULL, NA, length-0, or empty quotes "") -> normalize each to ""
-coerce_blank <- \(x) if (is.null(x) || length(x) != 1 || is.na(x) || !nzchar(x)) "" else as.character(x)
-est_start_input <- coerce_blank(params$est_date_start)
-est_end_input   <- coerce_blank(params$est_date_end)
-
-# Source fishery dates from the database if either param was left blank (default, "")
-needs_db <- !nzchar(est_start_input) || !nzchar(est_end_input)
-
-if (needs_db) {
-  fishery <- tryCatch(
-    creelutils::fishery_lut() |> # query and format
-      dplyr::filter(fishery_name == params$fishery_name) |>
-      dplyr::select(fishery_name, fishery_start_date, fishery_end_date),
-    error = \(e) NULL
-  )
-
-  # NULL returned means a connection issue
-  # row count != 1 means fishery name either absent from, or duplicated in, fishery_lut
-  if (is.null(fishery) || nrow(fishery) != 1) {
-    reason <- if (is.null(fishery)) "lookup failed (DB connection or query error)"
-              else if (nrow(fishery) == 0) "fishery_name not found in fishery_lut"
-              else "fishery_name matched multiple rows in fishery_lut"
-    cli::cli_abort(c(
-      "Cannot resolve estimation window for {.val {params$fishery_name}}.",
-      "x" = "{reason},",
-      "x" = "and no manual est_date_start / est_date_end were supplied."
-    ))
-  }
-
-  # Resolve fishery dates
-  # If the YAML param est_date_start is provided use that date (default is ""),
-  # otherwise use the start date from the fishery lookup table.
-  resolved_start <- if (nzchar(est_start_input)) as.Date(est_start_input) else as.Date(fishery$fishery_start_date)
-
-  # If the YAML param est_date_end is provided use that date (default is "").
-  # If a manual est_date_end is not provided, use whichever comes first:
-  #   1) the end date from the fishery lookup table, or 2) the system date minus one (yesterday).
-  #
-  #   This accounts for in-season versus post-season runs of the script:
-  #   - run within the fishery date range (in-season)  -> uses Sys.Date() - 1
-  #   - run after the fishery has closed (post-season) -> uses the lookup table end date
-  resolved_end <- if (nzchar(est_end_input)) as.Date(est_end_input) else min(as.Date(fishery$fishery_end_date), Sys.Date() - 1)
-  
-  # Abort when the resolved window is inverted (end before start)
-  if (resolved_end < resolved_start) {
-    cli::cli_abort("Invalid date range for {.val {params$fishery_name}}: end ({resolved_end}) is before start ({resolved_start}).")
-  }
-
-} else {
-  # Both est_date_start and est_date_end were manually supplied: use them verbatim
-  # The user is responsible for date validation
-  resolved_start <- as.Date(est_start_input)
-  resolved_end   <- as.Date(est_end_input)
-}
-
-# Bundle resolved dates into session-derived list
-# Downstream chunks read est_dates$... rather than params$..., 
-# This works around RStudio reseeding the params each time a chunk is run interactively
-est_dates <- list(
-  est_date_start = as.character(resolved_start),
-  est_date_end   = as.character(resolved_end)
+# If at least one date parameter is blank (default: ""), the database fishery lookup table (fishery_lut) is queried.
+# For in-season estimates, the end date is capped at `today - 1` (i.e., yesterday, the last completed day).
+# For post-season estimates, the fishery end date is used.
+est_dates <- resolve_dates(
+  params$fishery_name, 
+  params$est_date_start, 
+  params$est_date_end
 )
 ```
 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -137,22 +137,13 @@ if (needs_db) {
   resolved_end   <- as.Date(est_end_input)
 }
 
-# Update `params`
-# Record the environment (works for interactive and headless runs)
-env <- environment()
-
-# Capture the original lock state of YAML params so it can be restored afterward. 
-# Rmarkdown locks YAML during a render (e.g., an interactive 'knit' or a headless run (scheduled task))
-# A chunk-by-chunk interactive run does not lock params from being edited. 
-# Restoring the original state avoids locking it when it wasn't locked before (chunk-by-chunk operation)
-# and leaving it unlocked when the binding was locked by a render (interactive 'knit' or headless run)
-was_locked <- bindingIsLocked("params", env)
-
-# Unlock the render-bound params, supply resolved dates, then restore the lock state
-if (was_locked) unlockBinding("params", env)
-params$est_date_start <- as.character(resolved_start)
-params$est_date_end   <- as.character(resolved_end)
-if (was_locked) lockBinding("params", env)
+# Bundle resolved dates into session-derived list
+# Downstream chunks read est_dates$... rather than params$..., 
+# This works around RStudio reseeding the params each time a chunk is run interactively
+est_dates <- list(
+  est_date_start = as.character(resolved_start),
+  est_date_end   = as.character(resolved_end)
+)
 ```
 
 #### Selected catch groups
@@ -174,8 +165,8 @@ params$est_catch_groups |>
 
 ```{r, eval=params$report_type %in% c("detailed","summary")}
 tibble(
-  `Start date`= format(as.Date(params$est_date_start), "%m/%d/%Y"),
-  `End date` = format(as.Date(params$est_date_end), "%m/%d/%Y")
+  `Start date`= format(as.Date(est_dates$est_date_start), "%m/%d/%Y"),
+  `End date` = format(as.Date(est_dates$est_date_end), "%m/%d/%Y")
 ) |> 
   gt() |> 
 tab_header(
@@ -358,8 +349,8 @@ saveRDS(dwg, file.path(outputs_folders$inputs, "dwg_raw.rds"))
 
 dwg$days <- prep_days(
   params = params,
-  date_begin = params$est_date_start, 
-  date_end = params$est_date_end, 
+  date_begin = est_dates$est_date_start, 
+  date_end = est_dates$est_date_end, 
   weekends = params$days_wkend,
   # holidays = read_lines(paste(here(), "input_files/dates_holidays_2015_2030.txt", sep = "/")),
   lat = mean(dwg$ll$centroid_lat), #can/should consider smarter options
@@ -410,7 +401,7 @@ dwg$effort |>
 ```{r creel_effort}
 
 dwg$effort |>
-  filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |>
+  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |>
   distinct(section_num, location, event_date, tie_in_indicator, count_sequence) |>
   count(section_num, location, tie_in_indicator) |>
   mutate(
@@ -450,13 +441,13 @@ tab_header(
   ## NOTE: NAs in the "effort_type.y" column indicate that a census survey was conducted without the paired index count; if this occurs, the census data without a paired index count needs to be filter out for BSS model to run
 left_join(
   dwg$effort |>
-    filter(tie_in_indicator == 1, between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |> 
+    filter(tie_in_indicator == 1, between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
     mutate(effort_type = "Census") |> 
     select(water_body, event_date, section_num, effort_type) |> 
     distinct() |> 
     arrange(event_date, section_num),
   dwg$effort |>
-    filter(tie_in_indicator == 0, between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |> 
+    filter(tie_in_indicator == 0, between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
     mutate(effort_type = "Index") |> 
     select(water_body, event_date, section_num, effort_type) |> 
     distinct() |> 
@@ -470,7 +461,7 @@ left_join(
 ```{r creel_interview}
 # Total number of angler group interviews by section_num and fishing_location
 dwg$interview |>
-  filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |>
+  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |>
   count(section_num, fishing_location) |>
   arrange(section_num) |>
   gt() |> 
@@ -500,7 +491,7 @@ tab_style(
 ```{r interviews_date_section, include=FALSE}
 # Number of angler group interviews by event_date and section_num; 
 dwg$interview |>  
-  filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |> 
+  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
   count(section_num, event_date) |> 
   pivot_wider(names_from = section_num, values_from = n) |> 
   arrange(event_date) |> 
@@ -515,7 +506,7 @@ dwg$interview |>
 # Total number of "encounters" for each unique catch_group recorded during angler group interviews
 dwg$catch |>
   left_join(dwg$interview, by = "interview_id") |> 
-  filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))) |> 
+  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
   group_by(catch_group) |> 
   summarise(fish_count = sum(fish_count), .groups = "drop") |> 
 gt() |>
@@ -555,7 +546,7 @@ tab_style(
   interview_fishing_time <- 
     prep_dwg_interview_fishing_time(
       params = params,
-      dwg_interview = dwg$interview |> filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))),
+      dwg_interview = dwg$interview |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
       #person_count_type = params$person_count_type,
       min_fishing_time = params$min_fishing_time,
       study_design = params$study_design
@@ -604,7 +595,7 @@ tab_style(
       effort_index_summ <- 
         prep_dwg_effort_index(
           params = params,
-          eff = dwg$effort |> filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))),
+          eff = dwg$effort |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
           study_design = params$study_design,
           boat_type_collapse = params$boat_type_collapse,
           fish_location_determines_type = params$fish_location_determines_type,
@@ -627,7 +618,7 @@ tab_style(
     effort_census_summ <- 
       prep_dwg_effort_census(
         params = params,
-        eff = dwg$effort |> filter(between(event_date, as.Date(params$est_date_start), as.Date(params$est_date_end))),
+        eff = dwg$effort |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
         study_design = params$study_design,
         boat_type_collapse = params$boat_type_collapse,
         fish_location_determines_type = params$fish_location_determines_type,
@@ -804,7 +795,7 @@ estimates_pe$effort |>
     .groups = "drop"
   ) |> 
   pivot_wider(names_from = section_num, values_from = E_sum) |> 
-  gt(caption = paste("Estimated effort (angler hours) by fishing section from", params$est_date_start, "to", params$est_date_end)) |> 
+  gt(caption = paste("Estimated effort (angler hours) by fishing section from", est_dates$est_date_start, "to", est_dates$est_date_end)) |> 
   tab_options(
     heading.title.font.size = px(14),
     table.font.color = "black"

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -76,6 +76,11 @@ library("digest")
 library(creelutils)
 ```
 
+```{r, load_functions, message=FALSE}
+# Load CreelEstimates functions (pre-package method)
+walk(list.files(here("R_functions"), full.names = T), source)
+```
+
 ```{r resolve_dates, message=FALSE}
 # Dynamically source fishery start and end dates from the Postgres creel database.
 # Manually entered dates always override and validation of manual dates is up to the user.
@@ -148,9 +153,6 @@ if (params$enable_cache) {
 } else {
   cli_alert_warning("Cache is DISABLED - all chunks will be re-executed")
 }
-
-# Load functions (pre-package method)
-walk(list.files(here("R_functions"), full.names = T), source)
 
 # adjust day_length inputs
 day_length_inputs <- list()

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -4,8 +4,8 @@ date: "`r Sys.Date()`"
 params:
   project_name: "District 14"
   fishery_name: "Skagit spring Chinook 2026 upper"
-  est_date_start: "2026-05-16"
-  est_date_end: "2026-05-25"
+  est_date_start: ""
+  est_date_end: ""
   est_catch_groups: !r data.frame(rbind(
     c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
     c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
@@ -74,6 +74,85 @@ library("digest")
 # Load packages from source
 # devtools::install_github("wdfw-fp/creelutils")
 library(creelutils)
+```
+
+```{r resolve_dates, message=FALSE}
+# Resolve est_date_start / est_date_end for both interactive and headless runs.
+# Manual YAML dates win; blanks are sourced from the fishery lookup table,
+# with the end date capped at 'yesterday' for in-season runs.
+
+# If fishery dates are manually entered -> pass through unchanged
+# If fishery dates are not entered (param as NULL, NA, length-0, or empty quotes "") -> normalize each to ""
+coerce_blank <- \(x) if (is.null(x) || length(x) != 1 || is.na(x) || !nzchar(x)) "" else as.character(x)
+est_start_input <- coerce_blank(params$est_date_start)
+est_end_input   <- coerce_blank(params$est_date_end)
+
+# Source fishery dates from the database if either param was left blank (default, "")
+needs_db <- !nzchar(est_start_input) || !nzchar(est_end_input)
+
+if (needs_db) {
+  fishery <- tryCatch(
+    creelutils::fishery_lut() |> # query and format
+      dplyr::filter(fishery_name == params$fishery_name) |>
+      dplyr::select(fishery_name, fishery_start_date, fishery_end_date),
+    error = \(e) NULL
+  )
+
+  # NULL returned means a connection issue
+  # row count != 1 means fishery name either absent from, or duplicated in, fishery_lut
+  if (is.null(fishery) || nrow(fishery) != 1) {
+    reason <- if (is.null(fishery)) "lookup failed (DB connection or query error)"
+              else if (nrow(fishery) == 0) "fishery_name not found in fishery_lut"
+              else "fishery_name matched multiple rows in fishery_lut"
+    cli::cli_abort(c(
+      "Cannot resolve estimation window for {.val {params$fishery_name}}.",
+      "x" = "{reason},",
+      "x" = "and no manual est_date_start / est_date_end were supplied."
+    ))
+  }
+
+  # Resolve fishery dates
+  # If the YAML param est_date_start is provided use that date (default is ""),
+  # otherwise use the start date from the fishery lookup table.
+  resolved_start <- if (nzchar(est_start_input)) as.Date(est_start_input) else as.Date(fishery$fishery_start_date)
+
+  # If the YAML param est_date_end is provided use that date (default is "").
+  # If a manual est_date_end is not provided, use whichever comes first:
+  #   1) the end date from the fishery lookup table, or 2) the system date minus one (yesterday).
+  #
+  #   This accounts for in-season versus post-season runs of the script:
+  #   - run within the fishery date range (in-season)  -> uses Sys.Date() - 1
+  #   - run after the fishery has closed (post-season) -> uses the lookup table end date
+  resolved_end <- if (nzchar(est_end_input)) as.Date(est_end_input) else min(as.Date(fishery$fishery_end_date), Sys.Date() - 1)
+  
+  # Abort when the resolved window is inverted (end before start)
+  if (resolved_end < resolved_start) {
+    cli::cli_abort("Invalid date range for {.val {params$fishery_name}}: end ({resolved_end}) is before start ({resolved_start}).")
+  }
+
+} else {
+  # Both est_date_start and est_date_end were manually supplied: use them verbatim
+  # The user is responsible for date validation
+  resolved_start <- as.Date(est_start_input)
+  resolved_end   <- as.Date(est_end_input)
+}
+
+# Update `params`
+# Record the environment (works for interactive and headless runs)
+env <- environment()
+
+# Capture the original lock state of YAML params so it can be restored afterward. 
+# Rmarkdown locks YAML during a render (e.g., an interactive 'knit' or a headless run (scheduled task))
+# A chunk-by-chunk interactive run does not lock params from being edited. 
+# Restoring the original state avoids locking it when it wasn't locked before (chunk-by-chunk operation)
+# and leaving it unlocked when the binding was locked by a render (interactive 'knit' or headless run)
+was_locked <- bindingIsLocked("params", env)
+
+# Unlock the render-bound params, supply resolved dates, then restore the lock state
+if (was_locked) unlockBinding("params", env)
+params$est_date_start <- as.character(resolved_start)
+params$est_date_end   <- as.character(resolved_end)
+if (was_locked) lockBinding("params", env)
 ```
 
 #### Selected catch groups


### PR DESCRIPTION
This PR adds the feature to dynamically source fishery dates from the creel database.

Previously, for every fishery, and often every analysis session, the YAML parameters `params$est_date_start` and `params$est_date_end` were manually edited. For in-season estimation, this meant frequently updating the fishery end date.

Changes:
 - `params` now defaults to blank quotes ("") for `est_date_start` and `est_date_end` instead of a placeholder value from an example fishery
 - Establish a new function `resolve_dates()` that accepts the default blank quotes, manually entered dates, or a combination, and queries the fishery lookup table (lut) in the creel database to source the needed dates.
   - Relies on `creelutils::fishery_lut()`
   - Manually entered dates override. Any date (with valid format "YYYY-MM-DD") supplied will not be replaced with a date from the fishery lookup table. Even out of bounds or otherwise incorrect values - manual validation is on the user.
- Move single line `source()` call where we load CreelEstimates functions higher in the script. Into a new chunk immediately after loading the package dependencies but before resolving dates.
- Downstream of `resolve_dates()`, **replace all instances of `params$est_date_[start/end]` with `est_dates$est_date_[start/end]`**.
  - After running the function, the `est_dates` list is the source of truth over `params$est_date_[start/end]`. Since it is run very early in the script, other essential early steps like `prep_days()` and the creation of `param_hash` for caching use it.
  - `est_dates` is a drop-in replacement for `params` everywhere that dates are referenced in the template script.

Conditional behavior on start dates:
If the YAML param `est_date_start` is provided use that date, otherwise use the start date from the fishery lookup table.

Conditional behavior on end dates:
If the YAML param `est_date_end` is provided use that date. If a manual `est_date_end` is not provided, use **whichever comes first**: 1) the end date from the fishery lookup table, or 2) the system date minus one (yesterday). For in-season estimation where estimates are produced frequently, the end date can now update dynamically.

This accounts for in-season versus post-season runs of the script:
- a run within the fishery date range (in-season) -> uses Sys.Date() - 1
- a run after the fishery has closed (post-season) -> uses the lookup table end date

**!! IMPORTANT !!** This is the first integration of a function that pulls data inaccessible to the public. The existing public views of database tables do not display pre-season fishery start and end dates. If one or more `params$est_date_` are blank, a lazy data connection is opened, since `resolve_dates()` calls `creelutils::fishery_lut()`. To use this feature, it forces the requirement of proper configuration and at least read-only access for each user. However, to maintain reproducibility both dates would just have to be manually supplied and no database connection is required.
