### PR TITLE
Fix BSS run crashes on low-catch datasets (poisson_rng overflow → NaN generated quantities)

### DIFF
--- a/R_functions/get_bss_season_results.R
+++ b/R_functions/get_bss_season_results.R
@@ -17,7 +17,10 @@ get_bss_season_results <- function(ecg_draws, ecg_name) {
     
     # Check for missing values in catch
     if (any(is.na(catch_results$C_sum)) || any(is.nan(catch_results$C_sum))) {
-      cli::cli_alert_warning("Missing or NaN values detected in C_sum for catch group: {ecg_name}")
+      n_nan_c <- sum(is.na(catch_results$C_sum) | is.nan(catch_results$C_sum))
+      n_total_c <- length(catch_results$C_sum)
+      pct_nan_c <- round(100 * n_nan_c / n_total_c, 1)
+      cli::cli_alert_warning("Missing or NaN values detected in C_sum for catch group: {ecg_name} ({n_nan_c} of {n_total_c} draws, {pct_nan_c}%)")
     }
     
     catch_quantiles <- catch_results |>
@@ -34,7 +37,10 @@ get_bss_season_results <- function(ecg_draws, ecg_name) {
     
     # Check for missing values in effort
     if (any(is.na(effort_results$E_sum)) || any(is.nan(effort_results$E_sum))) {
-      cli::cli_alert_warning("Missing or NaN values detected in E_sum for catch group: {ecg_name}")
+      n_nan_e <- sum(is.na(effort_results$E_sum) | is.nan(effort_results$E_sum))
+      n_total_e <- length(effort_results$E_sum)
+      pct_nan_e <- round(100 * n_nan_e / n_total_e, 1)
+      cli::cli_alert_warning("Missing or NaN values detected in E_sum for catch group: {ecg_name} ({n_nan_e} of {n_total_e} draws, {pct_nan_e}%)")
     }
     
     effort_quantiles <- effort_results |>

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1309,41 +1309,52 @@ Tables show the proportion of observations that fell outside 95% posterior predi
 ppc_coverage_combined <- purrr::map_df(
   names(estimates_bss),
   ~{
-    estimates_bss[[.x]]$ppc_results$p_fit |>
+    p_fit <- estimates_bss[[.x]]$ppc_results$p_fit
+    if (is.null(p_fit)) {
+      cli::cli_alert_info("Skipping PPC coverage summary for catch group {.x}: no PPC results (likely NaN generated quantities from low catch data).")
+      return(NULL)
+    }
+    p_fit |>
       mutate(catch_group = .x) # convert to "safe name" to account for |
   }
-) |>
-  select(catch_group, Parameter, Section = section, Gear = gear, 
-         `Fit count` = fit_count, `No fit count` = no_fit_count, 
-         `Total n` = total_count, `Interval coverage` = p_fit)
+)
 
-# Display as formatted table
-ppc_coverage_combined_table <- ppc_coverage_combined |>
-  gt(groupname_col = "catch_group") |>
-  fmt_number(columns = `Interval coverage`, decimals = 3) |>
-  tab_header(
-    title = "PPC 95% Interval Coverage",
-    subtitle = "Proportion of observations within 95% posterior predictive intervals"
-  ) |>
-  tab_style(
-    style = cell_fill(color = "lightgreen"),
-    locations = cells_body(
-      columns = `Interval coverage`,
-      rows = `Interval coverage` >= 0.90 & `Interval coverage` <= 0.98
-    )
-  ) |>
-  tab_style(
-    style = cell_fill(color = "yellow"),
-    locations = cells_body(
-      columns = `Interval coverage`,
-      rows = `Interval coverage` < 0.90 | `Interval coverage` > 0.98
-    )
-  )
+if (nrow(ppc_coverage_combined) == 0) {
+  cli::cli_alert_warning("No catch groups had valid PPC results; skipping PPC interval coverage summary table.")
+} else {
+  ppc_coverage_combined <- ppc_coverage_combined |>
+    select(catch_group, Parameter, Section = section, Gear = gear,
+           `Fit count` = fit_count, `No fit count` = no_fit_count,
+           `Total n` = total_count, `Interval coverage` = p_fit)
 
-  ppc_coverage_combined_table
-  
-  # Save to figures folder
-  save_gt_table(ppc_coverage_combined_table, paste0("ppc_coverage_combined"))
+  # Display as formatted table
+  ppc_coverage_combined_table <- ppc_coverage_combined |>
+    gt(groupname_col = "catch_group") |>
+    fmt_number(columns = `Interval coverage`, decimals = 3) |>
+    tab_header(
+      title = "PPC 95% Interval Coverage",
+      subtitle = "Proportion of observations within 95% posterior predictive intervals"
+    ) |>
+    tab_style(
+      style = cell_fill(color = "lightgreen"),
+      locations = cells_body(
+        columns = `Interval coverage`,
+        rows = `Interval coverage` >= 0.90 & `Interval coverage` <= 0.98
+      )
+    ) |>
+    tab_style(
+      style = cell_fill(color = "yellow"),
+      locations = cells_body(
+        columns = `Interval coverage`,
+        rows = `Interval coverage` < 0.90 | `Interval coverage` > 0.98
+      )
+    )
+
+    ppc_coverage_combined_table
+
+    # Save to figures folder
+    save_gt_table(ppc_coverage_combined_table, paste0("ppc_coverage_combined"))
+}
 ```
 
 #### PPC plots
@@ -1354,45 +1365,41 @@ Plots show observations versus 95% posterior predictive intervals (PPI) for each
 # Display and save all PPC plots for each catch group
 purrr::iwalk(estimates_bss, ~{
   # cat("\n### Catch Group:", .y, "\n\n")
-  
+
   # Create safe filename version of catch group name
   safe_catch_group <- stringr::str_replace_all(.y, "[^[:alnum:]]", "_")
-  
+
+  # Skip NULL plots (e.g. catch group had no valid PPC results due to NaN
+  # generated quantities on low-catch data) instead of erroring in save_plot()
+  show_and_save_ppc <- function(plot_obj, filename) {
+    if (is.null(plot_obj)) return(invisible(NULL))
+    print(plot_obj)
+    save_plot(plot_obj, filename, width = 10, height = 8)
+  }
+
   # V_I_PPC
-  print(.x$ppc_results$plots$V_I_PPC_plt)
-  save_plot(.x$ppc_results$plots$V_I_PPC_plt, 
-            paste0("ppc_V_I_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
-  
+  show_and_save_ppc(.x$ppc_results$plots$V_I_PPC_plt,
+                     paste0("ppc_V_I_", safe_catch_group, ".png"))
+
   # T_I_PPC
-  print(.x$ppc_results$plots$T_I_PPC_plt)
-  save_plot(.x$ppc_results$plots$T_I_PPC_plt, 
-            paste0("ppc_T_I_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
-  
+  show_and_save_ppc(.x$ppc_results$plots$T_I_PPC_plt,
+                     paste0("ppc_T_I_", safe_catch_group, ".png"))
+
   # E_s_PPC
-  print(.x$ppc_results$plots$E_s_PPC_plt)
-  save_plot(.x$ppc_results$plots$E_s_PPC_plt, 
-            paste0("ppc_E_s_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
-  
+  show_and_save_ppc(.x$ppc_results$plots$E_s_PPC_plt,
+                     paste0("ppc_E_s_", safe_catch_group, ".png"))
+
   # c_PPC
-  print(.x$ppc_results$plots$c_PPC_plt)
-  save_plot(.x$ppc_results$plots$c_PPC_plt, 
-            paste0("ppc_c_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
-  
+  show_and_save_ppc(.x$ppc_results$plots$c_PPC_plt,
+                     paste0("ppc_c_", safe_catch_group, ".png"))
+
   # V_A_PPC
-  print(.x$ppc_results$plots$V_A_PPC_plt)
-  save_plot(.x$ppc_results$plots$V_A_PPC_plt, 
-            paste0("ppc_V_A_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
-  
+  show_and_save_ppc(.x$ppc_results$plots$V_A_PPC_plt,
+                     paste0("ppc_V_A_", safe_catch_group, ".png"))
+
   # T_A_PPC
-  print(.x$ppc_results$plots$T_A_PPC_plt)
-  save_plot(.x$ppc_results$plots$T_A_PPC_plt, 
-            paste0("ppc_T_A_", safe_catch_group, ".png"), 
-            width = 10, height = 8)
+  show_and_save_ppc(.x$ppc_results$plots$T_A_PPC_plt,
+                     paste0("ppc_T_A_", safe_catch_group, ".png"))
 })
 ```
 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1008,32 +1008,70 @@ for(ecg in names(inputs_bss)) {
   cat(diagnostics_keep$bss_settings_cg, sep = "\n")
 
   # trace plots
-  invisible(diagnostics_keep$traceplots <- mcmc_trace(
-    ecg_fit, 
-    pars = c(
-      "C_sum", "E_sum", "phi_C_scaled", "phi_E_scaled", 
-      "sigma_r_C", "sigma_r_E", "sigma_eps_C", "sigma_eps_E",
-      "sigma_mu_C", "sigma_mu_E", "phi_C", "phi_E", 
-      "r_C", "r_E", "B1", "lp__"
-    ),
-    np = nuts_params(ecg_fit)
-  ) +
-    labs(
-      x = "Post-warmup iteration",
-      title = paste("Trace plots for catch group:", ecg)
-    ) +
-    theme(axis.text.x = element_text(angle = 45, hjust = 1)))
-  
-  safe_name <- stringr::str_replace_all(ecg, "[^[:alnum:]]", "_")
-    
-  # Save the traceplot
-  save_plot(
-    diagnostics_keep$traceplots, 
-    paste0("traceplot_", safe_name, ".png"),
-    width = 12,
-    height = 10
+  trace_pars <- c(
+    "C_sum", "E_sum", "phi_C_scaled", "phi_E_scaled",
+    "sigma_r_C", "sigma_r_E", "sigma_eps_C", "sigma_eps_E",
+    "sigma_mu_C", "sigma_mu_E", "phi_C", "phi_E",
+    "r_C", "r_E", "B1", "lp__"
   )
-      
+
+  build_trace_plot <- function(pars) {
+    mcmc_trace(
+      ecg_fit,
+      pars = pars,
+      np = nuts_params(ecg_fit)
+    ) +
+      labs(
+        x = "Post-warmup iteration",
+        title = paste("Trace plots for catch group:", ecg)
+      ) +
+      theme(axis.text.x = element_text(angle = 45, hjust = 1))
+  }
+
+  # generated-quantities draws can be NaN when poisson_rng hits its rate
+  # ceiling (>= 2^30) on low-catch data; mcmc_trace() aborts on any NaN, so
+  # fall back to the subset of pars that are actually clean before giving up
+  invisible(diagnostics_keep$traceplots <- tryCatch({
+    build_trace_plot(trace_pars)
+  }, error = function(e) {
+    cli::cli_alert_warning(paste0(
+      "Trace plot failed for catch group {ecg}: {e$message} -- this is almost ",
+      "certainly NaN generated-quantities draws (C_sum/E_sum) from poisson_rng ",
+      "rate overflow on low-catch data. Retrying with only the NaN-free parameters."
+    ))
+
+    clean_pars <- purrr::keep(trace_pars, function(par) {
+      draws <- tryCatch(as.matrix(ecg_fit, pars = par), error = function(e2) NULL)
+      !is.null(draws) && !anyNA(draws)
+    })
+
+    if (length(clean_pars) == 0) {
+      cli::cli_alert_warning("No NaN-free parameters remain for catch group {ecg}; skipping trace plot entirely.")
+      return(NULL)
+    }
+
+    tryCatch({
+      build_trace_plot(clean_pars)
+    }, error = function(e3) {
+      cli::cli_alert_warning("Partial trace plot also failed for catch group {ecg}: {e3$message}. Skipping trace plot entirely.")
+      NULL
+    })
+  }))
+
+  safe_name <- stringr::str_replace_all(ecg, "[^[:alnum:]]", "_")
+
+  # Save the traceplot (skipped when NaN draws prevented any plot from being built)
+  if (!is.null(diagnostics_keep$traceplots)) {
+    save_plot(
+      diagnostics_keep$traceplots,
+      paste0("traceplot_", safe_name, ".png"),
+      width = 12,
+      height = 10
+    )
+  } else {
+    cli::cli_alert_info("Skipping traceplot save for catch group {ecg} (no plot available).")
+  }
+
   diagnostics_bss[[ecg]] <- diagnostics_keep
   
   # Additional memory cleanup - remove fit object after extracting what we need
@@ -1101,9 +1139,13 @@ for (ecg in names(convergence_tables)) {
 ```{r bss_trace_plots, eval=TRUE, fig.keep='all', dependson="estimates_bss"}
 # Plot and save traceplots
 purrr::iwalk(diagnostics_bss, function(diag, ecg) {
-  # Print to document
-  print(diag$traceplots)
-  
+  # Print to document (traceplots is NULL when NaN draws prevented plotting)
+  if (!is.null(diag$traceplots)) {
+    print(diag$traceplots)
+  } else {
+    cli::cli_alert_info("Trace plots skipped for catch group {ecg} (NaN draws).")
+  }
+
   # Save to figures folder
   # save_plot(
   #   diag$traceplots,


### PR DESCRIPTION
## Summary
- On low-catch datasets, `poisson_rng` in the Stan model's `generated quantities` block throws when the catch rate exceeds Stan's 2^30 cap (weakly-identified CPUE posterior + default heavy-tailed priors). This is benign to HMC sampling but zeroes out that draw's entire generated-quantities vector (`C_sum`, `E_sum`, `Omega_C`, etc. → NaN), which previously crashed three separate downstream R steps that assumed always-populated output: the `mcmc_trace()` diagnostics call, the PPC interval-coverage table, and the PPC plot display.
- All three now fail gracefully — skipping the affected catch group/diagnostic with a warning instead of aborting the entire multi-catch-group run — rather than fabricating values or silently hiding the issue. `get_bss_season_results.R` also now reports the count/percentage of NaN draws dropped per catch group for visibility.
- The Stan model itself is unchanged: capping `poisson_rng` would hide a real prior-misspecification signal rather than fix it, so that's left as a follow-up if the default CPUE hyperpriors need tightening for near-zero-catch groups.

## Test plan
- [x] Verified against a real low-catch dataset that previously crashed on `mcmc_trace()`
- [x] Verified against a 6-catch-group run that previously crashed in `ppc_interval_coverage` at a specific low-catch group
- [x] Tested across both interactive and rendered (`knit`) runs

Closes #81

---
_Generated by [Claude Code](https://claude.ai/code/session_01TufRZqFfQvDA4uTE6VSYnu)_ 